### PR TITLE
Update config.inc.TEMPLATE

### DIFF
--- a/installer/config.inc.TEMPLATE
+++ b/installer/config.inc.TEMPLATE
@@ -9,7 +9,7 @@ export NFS_ROOT='192.168.1.10:/volume1/'
 # Some NFS configurations may need special mount options. You can specify
 # them here. The default value is verified on my camera with a NFS v3 share
 # on my home server.
-export NFS_OPTIONS='-o nolock,rw'
+export NFS_OPTIONS='-o nolock,rw,noatime,nodiratime'
 
 # Uncomment and modify the AUTO_REBOOT variable to automatically reboot
 # the camera at a specific minute. Time is specified in "HH:MM" format


### PR DESCRIPTION
since the profile of nfs usage is mostly a 'write', adding more tuning:
'If write dominates, make sure the clients are using noatime,nodiratime to avoid updating access times. Make sure your server's local file system access has been optimized.'
credits: https://cromwell-intl.com/open-source/performance-tuning/nfs.html