### PR TITLE
Add fallback to connect to wifi when Wyzecam v3 debug enabled.

### DIFF
--- a/installer/config.inc.TEMPLATE
+++ b/installer/config.inc.TEMPLATE
@@ -78,3 +78,15 @@ export NFS_ROOT='192.168.1.10:/volume1'
 #   openssl passwd -1 -salt <YOUR SALT> <YOUR PASSWORD>
 # Use the result to replace sample hash ($1$MYSALT$3Sy1OLRk4kTa7P6fvzwp71)
 # export PASSWD_SHADOW='root:$1$MYSALT$3Sy1OLRk4kTa7P6fvzwp71:10933:0:99999:7:::'
+
+# !!!ADVANCED USER!!!
+# If configured incorrectly you may brick your device!
+# WYZE_DEBUG=1
+
+# If WYZE_DEBUG, Uncomment this to enable automatically updating wlan.inc file based on file
+# < camera_folder > /wyzehacks/wlan.new.This will be checked every one minute.
+# export AUTO_WLAN_CONFIG = 1
+
+# If WYZE_DEBUG, Uncommect to specify a default WLAN AP to connect to
+# export WLAN_SSID = "WyzeHacks"
+# export WLAN_KEY = "ismart12"

--- a/installer/config.inc.TEMPLATE
+++ b/installer/config.inc.TEMPLATE
@@ -81,12 +81,12 @@ export NFS_ROOT='192.168.1.10:/volume1'
 
 # !!!ADVANCED USER!!!
 # If configured incorrectly you may brick your device!
-# WYZE_DEBUG=1
+# export WYZE_DEBUG=1
 
 # If WYZE_DEBUG, Uncomment this to enable automatically updating wlan.inc file based on file
 # < camera_folder > /wyzehacks/wlan.new.This will be checked every one minute.
-# export AUTO_WLAN_CONFIG = 1
+# export AUTO_WLAN_CONFIG=1
 
 # If WYZE_DEBUG, Uncommect to specify a default WLAN AP to connect to
-# export WLAN_SSID = "WyzeHacks"
-# export WLAN_KEY = "ismart12"
+# export WLAN_SSID="WyzeHacks"
+# export WLAN_KEY="ismart12"

--- a/wyze_hack/hack_ver.inc
+++ b/wyze_hack/hack_ver.inc
@@ -1,1 +1,1 @@
-export WYZEHACK_VER=0.5.05
+export WYZEHACK_VER=0.5.04.1

--- a/wyze_hack/hack_ver.inc
+++ b/wyze_hack/hack_ver.inc
@@ -1,1 +1,1 @@
-export WYZEHACK_VER=0.5.04.1
+export WYZEHACK_VER=0.5.05

--- a/wyze_hack/hack_ver.inc
+++ b/wyze_hack/hack_ver.inc
@@ -1,1 +1,1 @@
-export WYZEHACK_VER=0.5.04
+export WYZEHACK_VER=0.5.04.1

--- a/wyze_hack/main.sh
+++ b/wyze_hack/main.sh
@@ -8,6 +8,7 @@ export WYZEHACK_BIN=/configs/wyze_hack.sh
 export WYZECAM_DEBUG=/configs/.debug_flag
 export WYZEHACK_WLAN_CFG=/configs/wlan.cfg
 export WYZEHACK_WLAN_PID=$WYZEHACK_DIR/run/wlan.pid
+export WYZEHACK_DHCP_PID=$WYZEHACK_DIR/run/dhcp.pid
 export WLAN_SSID = "WyzeHacks"
 export WLAN_SSID = "ismart12"
 
@@ -285,7 +286,7 @@ check_wlan_config() {
         kill -9 `cat $WYZEHACK_WLAN_PID`
         sleep 5
         /bin/wpa_supplicant -D nl80211 -i wlan0 -c $WYZEHACK_WLAN_CFG -B -P $WYZEHACK_WLAN_PID
-        udhcpc -i /dev/wlan0
+        #udhcpc -i /dev/wlan0
     fi
     return 0
 }
@@ -616,7 +617,7 @@ cmd_run() {
         fi
         # Start wpa_supplicant daemon
         /bin/wpa_supplicant -D nl80211 -i wlan0 -c $WYZEHACK_WLAN_CFG -B -P $WYZEHACK_WLAN_PID
-        udhcpc -i /dev/wlan0
+        udhcpc -i wlan0 -p $WYZEHACK_DHCP_PID -b
     fi
 
     # Wait until WIFI is connected

--- a/wyze_hack/main.sh
+++ b/wyze_hack/main.sh
@@ -9,9 +9,8 @@ export WYZECAM_DEBUG=/configs/.debug_flag
 export WYZEHACK_WLAN_CFG=/configs/wlan.cfg
 export WYZEHACK_WLAN_PID=$WYZEHACK_DIR/run/wlan.pid
 export WYZEHACK_DHCP_PID=$WYZEHACK_DIR/run/dhcp.pid
-export WLAN_SSID = "WyzeHacks"
-export WLAN_SSID = "ismart12"
-
+export WLAN_SSID="WyzeHacks"
+export WLAN_SSID="ismart12"
 
 if grep "wyze_hack.sh" /etc/init.d/rcS; then
     export WYZEINIT_SCRIPT=/system/init/app_init.sh

--- a/wyze_hack/main.sh
+++ b/wyze_hack/main.sh
@@ -597,8 +597,6 @@ cmd_run() {
         LD_PRELOAD=$WYZEHACK_DIR/bin/libhacks.so $WYZEINIT_SCRIPT &
     fi
 
-    mkdir -p $WYZEHACK_DIR/run
-
     # If WYZECAM_DEBUG, iCamera will not run and we will get softbrick.
     # If debug mode
     if [ -f $WYZECAM_DEBUG ]; then
@@ -616,6 +614,8 @@ cmd_run() {
           echo "}" >> $WYZEHACK_WLAN_CFG
         fi
         # Start wpa_supplicant daemon
+        sleep 5
+        mkdir -p $WYZEHACK_DIR/run
         /bin/wpa_supplicant -D nl80211 -i wlan0 -c $WYZEHACK_WLAN_CFG -B -P $WYZEHACK_WLAN_PID &
         udhcpc -i wlan0 -p $WYZEHACK_DHCP_PID -b &
     fi

--- a/wyze_hack/main.sh
+++ b/wyze_hack/main.sh
@@ -285,6 +285,7 @@ check_wlan_config() {
         kill -9 `cat $WYZEHACK_WLAN_PID`
         sleep 5
         /bin/wpa_supplicant -D nl80211 -i wlan0 -c $WYZEHACK_WLAN_CFG -B -P $WYZEHACK_WLAN_PID
+        udhcpc -i /dev/wlan0
     fi
     return 0
 }
@@ -615,6 +616,7 @@ cmd_run() {
         fi
         # Start wpa_supplicant daemon
         /bin/wpa_supplicant -D nl80211 -i wlan0 -c $WYZEHACK_WLAN_CFG -B -P $WYZEHACK_WLAN_PID
+        udhcpc -i /dev/wlan0
     fi
 
     # Wait until WIFI is connected

--- a/wyze_hack/main.sh
+++ b/wyze_hack/main.sh
@@ -93,6 +93,7 @@ if [ -z "$NFS_ROOT" ]; then
     export SYNC_BOOT_LOG=
     export AUTO_UPDATE=
     export AUTO_CONFIG=
+    export AUTO_WLAN_CONFIG=
 fi
 
 play_sound() {
@@ -615,8 +616,8 @@ cmd_run() {
           echo "}" >> $WYZEHACK_WLAN_CFG
         fi
         # Start wpa_supplicant daemon
-        /bin/wpa_supplicant -D nl80211 -i wlan0 -c $WYZEHACK_WLAN_CFG -B -P $WYZEHACK_WLAN_PID
-        udhcpc -i wlan0 -p $WYZEHACK_DHCP_PID -b
+        /bin/wpa_supplicant -D nl80211 -i wlan0 -c $WYZEHACK_WLAN_CFG -B -P $WYZEHACK_WLAN_PID &
+        udhcpc -i wlan0 -p $WYZEHACK_DHCP_PID -b &
     fi
 
     # Wait until WIFI is connected


### PR DESCRIPTION
Background: While exploring methods of establishing an rtsp stream from the camera I noticed that killing `/system/bin/assis`,  `/system/bin/hl_client`,  and/or `/system/bin/iCamera` the system would reboot a few moments after. Thus preventing any attempts to poke and prod around the system. Reviewing the init process shows that if `/configs/.debug_flag` exists app_init.sh will not spawn these processes. However after creating this file, I ended up soft bricking my device because it will no longer connect to the network.

This PR resolves this matter by implementing a few configuration options to:
A, Enable/Disable the debug mode.
B, look for `wlan.new` in the nfs share to update wpa_supplicant.conf and restart wpa_supplicant
C, Specify WLAN SSID and KEY in the config.