### PR TITLE
replacing df with ls for nfs check

### DIFF
--- a/wyze_hack/main.sh
+++ b/wyze_hack/main.sh
@@ -455,7 +455,7 @@ check_nfs() {
         TIMEOUT_ARGS="$NFS_TIMEOUT"
     fi
 
-    if ! timeout $TIMEOUT_ARGS df /media/mmcblk0p1 > /dev/null 2>&1;
+    if ! timeout $TIMEOUT_ARGS ls /media/mmcblk0p1 > /dev/null 2>&1;
     then
         echo "WyzeHack: NFS no longer mounted as /media/mmcblk0p1"
         return 1


### PR DESCRIPTION
The check_nfs df breaks and exits 1 on large nfs shares and causes the camera to keep rebooting.
<pre>
[root@WyzeCam-C428:~]# df || echo broken 
Filesystem           1K-blocks      Used Available Use% Mounted on
/dev/root                 3712      3712         0 100% /
tmpfs                    45736       652     45084   1% /dev
tmpfs                    45736       940     44796   2% /tmp
tmpfs                    45736         8     45728   0% /run
media                    45736         0     45736   0% /media
/dev/mtdblock3            3584      3584         0 100% /system
/dev/mtdblock6             384       120       264  31% /configs
df: /mnt: Value too large for defined data type
df: /media/mmcblk0p1: Value too large for defined data type
broken
[root@WyzeCam-C428:~]#
</pre>
Using ls should provide the same functionality (verifying nfs is working), and works correctly in my testing (shut down nfs server and it failed as expected).  